### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+---
+update_configs:
+- directory: "/"
+  package_manager: go:dep
+  update_schedule: weekly


### PR DESCRIPTION
Note that dependabot does not yet support vendoring, https://github.com/dependabot/dependabot-core/issues/670,  so on receiving a pull request you will still need to `dep ensure` on the PR branch.