### PR TITLE
Add hostname param to pool resource

### DIFF
--- a/ci/pipelines/bbr/pipeline.yml
+++ b/ci/pipelines/bbr/pipeline.yml
@@ -282,6 +282,7 @@ resources:
   type: pcf-pool
   source:
     api_token: ((toolsmiths.api_token))
+    hostname: environments.toolsmiths.cf-app.com
     pool_name: us_2_11_lts2
 
 - name: cryogenics-meta


### PR DESCRIPTION
- This fixes the "get" step erroring with:
  null health check failed. <https://null/health_check/custom.json> Resource unavailable.

Signed-off-by: Neil Hickey <nhickey@vmware.com>